### PR TITLE
fixed 404 bug masquerading as 400 bug.

### DIFF
--- a/acceptance/check_test.go
+++ b/acceptance/check_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Check", func() {
 			snapshotTimestamp = createBlobWithSnapshot(container, "example.json")
 		})
 
-		It("returns just the latest blob snapshot version", func() {
+		It("returns just the latest blob", func() {
 			check := exec.Command(pathToCheck)
 			check.Stderr = os.Stderr
 
@@ -50,8 +50,7 @@ var _ = Describe("Check", func() {
 						"storage_account_key": %q,
 						"container": %q,
 						"versioned_file": "example.json"
-					},
-					"version": { "snapshot": "2017-08-08T23:27:16.2942812Z" }
+					}
 				}`,
 				config.StorageAccountName,
 				config.StorageAccountKey,

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -58,13 +58,11 @@ var _ = Describe("In", func() {
 						"storage_account_key": %q,
 						"container": %q,
 						"versioned_file": "example.json"
-					},
-					"version": { "snapshot": %q }
+					}
 				}`,
 				config.StorageAccountName,
 				config.StorageAccountKey,
 				container,
-				snapshotTimestamp.Format(time.RFC3339Nano),
 			))
 			Expect(err).NotTo(HaveOccurred())
 
@@ -83,7 +81,6 @@ var _ = Describe("In", func() {
 			err = json.Unmarshal(outputJSON, &output)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(output.Version.Snapshot).To(Equal(*snapshotTimestamp))
 			Expect(output.Metadata[0].Name).To(Equal("filename"))
 			Expect(output.Metadata[0].Value).To(Equal("example.json"))
 			Expect(output.Metadata[1].Name).To(Equal("url"))

--- a/api/check_test.go
+++ b/api/check_test.go
@@ -2,7 +2,6 @@ package api_test
 
 import (
 	"errors"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/pivotal-cf/azure-blobstore-resource/api"
@@ -25,48 +24,26 @@ var _ = Describe("Check", func() {
 
 	Describe("LatestVersion", func() {
 		Context("when given a filename", func() {
-			var (
-				expectedSnapshot time.Time
-			)
 
 			BeforeEach(func() {
-				expectedSnapshot = time.Date(2017, time.January, 02, 01, 01, 01, 01, time.UTC)
 				azureClient.ListBlobsCall.Returns.BlobListResponse = storage.BlobListResponse{
 					Blobs: []storage.Blob{
 						storage.Blob{
 							Name:     "example.json",
-							Snapshot: time.Date(2017, time.January, 01, 01, 01, 01, 01, time.UTC),
 						},
 						storage.Blob{
 							Name:     "example.json",
-							Snapshot: expectedSnapshot,
 						},
 						storage.Blob{
 							Name:     "example.json",
-							Snapshot: time.Date(0001, time.January, 01, 0, 0, 0, 0, time.UTC),
 						},
 					},
 				}
 			})
 
-			It("returns just the latest blob snapshot version", func() {
-				latestVersion, err := check.LatestVersion("example.json")
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(azureClient.ListBlobsCall.CallCount).To(Equal(1))
-				Expect(azureClient.ListBlobsCall.Receives.ListBlobsParameters).To(Equal(storage.ListBlobsParameters{
-					Prefix: "example.json",
-					Include: &storage.IncludeBlobDataset{
-						Snapshots: true,
-					},
-				}))
-				Expect(latestVersion.Snapshot).To(Equal(expectedSnapshot))
-			})
-
 			Context("when an error occurs", func() {
 				Context("when the azure client fails to list blobs", func() {
 					BeforeEach(func() {
-						expectedSnapshot = time.Date(2017, time.January, 02, 01, 01, 01, 01, time.UTC)
 						azureClient.ListBlobsCall.Returns.Error = errors.New("failed to list blobs")
 					})
 

--- a/api/in.go
+++ b/api/in.go
@@ -4,7 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
+	"errors"
+	"fmt"
 )
 
 type In struct {
@@ -17,15 +18,17 @@ func NewIn(azureClient azureClient) In {
 	}
 }
 
-func (i In) CopyBlobToDestination(destinationDir, blobName string, snapshot time.Time) error {
-	data, err := i.azureClient.Get(blobName, snapshot)
+// Downloads a blob to a target filepath location.
+func (i In) CopyBlobToDestination(destinationDir, blobName string) error {
+	data, err := i.azureClient.Get(blobName)
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("failed to get target blob: %s", err))
 	}
 
-	err = ioutil.WriteFile(filepath.Join(destinationDir, blobName), data, os.ModePerm)
+	targetPath := filepath.Join(destinationDir, blobName)
+	err = ioutil.WriteFile(targetPath, data, os.ModePerm)
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("failed to write target blob to %s: %s", targetPath, err))
 	}
 
 	return nil

--- a/api/in_test.go
+++ b/api/in_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"path/filepath"
-	"time"
-
 	"github.com/pivotal-cf/azure-blobstore-resource/api"
 	"github.com/pivotal-cf/azure-blobstore-resource/fakes"
 
@@ -31,22 +29,17 @@ var _ = Describe("In", func() {
 	})
 
 	Describe("CopyBlobToDestination", func() {
-		var (
-			snapshot time.Time
-		)
 
 		BeforeEach(func() {
 			azureClient.GetCall.Returns.BlobData = []byte(`{"key": "value"}`)
-			snapshot = time.Date(2017, time.January, 01, 01, 01, 01, 01, time.UTC)
 		})
 
 		It("copies blob from azure blobstore to local destination directory", func() {
-			err := in.CopyBlobToDestination(tempDir, "example.json", snapshot)
+			err := in.CopyBlobToDestination(tempDir, "example.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(azureClient.GetCall.CallCount).To(Equal(1))
 			Expect(azureClient.GetCall.Receives.BlobName).To(Equal("example.json"))
-			Expect(azureClient.GetCall.Receives.Snapshot).To(Equal(snapshot))
 
 			data, err := ioutil.ReadFile(filepath.Join(tempDir, "example.json"))
 			Expect(err).NotTo(HaveOccurred())
@@ -57,15 +50,15 @@ var _ = Describe("In", func() {
 			Context("when azure client fails to get a blob", func() {
 				It("returns an error", func() {
 					azureClient.GetCall.Returns.Error = errors.New("failed to get blob")
-					err := in.CopyBlobToDestination(tempDir, "example.json", snapshot)
-					Expect(err).To(MatchError("failed to get blob"))
+					err := in.CopyBlobToDestination(tempDir, "example.json")
+					Expect(err).To(MatchError("failed to get target blob: failed to get blob"))
 				})
 			})
 
 			Context("when it fails to write a file into the destination dir", func() {
 				It("returns an error", func() {
-					err := in.CopyBlobToDestination("/fake/dest/dir", "example.json", snapshot)
-					Expect(err).To(MatchError("open /fake/dest/dir/example.json: no such file or directory"))
+					err := in.CopyBlobToDestination("/fake/dest/dir", "example.json")
+					Expect(err).To(MatchError("failed to write target blob to /fake/dest/dir/example.json: open /fake/dest/dir/example.json: no such file or directory"))
 				})
 			})
 		})

--- a/api/interface.go
+++ b/api/interface.go
@@ -9,7 +9,7 @@ import (
 
 type azureClient interface {
 	ListBlobs(params storage.ListBlobsParameters) (storage.BlobListResponse, error)
-	Get(blobName string, snapshot time.Time) ([]byte, error)
+	Get(blobName string) ([]byte, error)
 	UploadFromStream(blobName string, stream io.Reader) error
 	CreateSnapshot(blobName string) (time.Time, error)
 }

--- a/azure/client.go
+++ b/azure/client.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"io/ioutil"
 	"time"
-
 	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
@@ -34,7 +33,7 @@ func (c Client) ListBlobs(params storage.ListBlobsParameters) (storage.BlobListR
 	return cnt.ListBlobs(params)
 }
 
-func (c Client) Get(blobName string, snapshot time.Time) ([]byte, error) {
+func (c Client) Get(blobName string) ([]byte, error) {
 	client, err := storage.NewBasicClient(c.storageAccountName, c.storageAccountKey)
 	if err != nil {
 		return []byte{}, err
@@ -43,9 +42,7 @@ func (c Client) Get(blobName string, snapshot time.Time) ([]byte, error) {
 	blobClient := client.GetBlobService()
 	cnt := blobClient.GetContainerReference(c.container)
 	blob := cnt.GetBlobReference(blobName)
-	blobReader, err := blob.Get(&storage.GetBlobOptions{
-		Snapshot: &snapshot,
-	})
+	blobReader, err := blob.Get(&storage.GetBlobOptions{})
 	if err != nil {
 		return []byte{}, err
 	}

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -29,7 +29,6 @@ func main() {
 	err = in.CopyBlobToDestination(
 		destinationDirectory,
 		inRequest.Source.VersionedFile,
-		inRequest.Version.Snapshot,
 	)
 	if err != nil {
 		log.Fatal("failed to copy blob: ", err)

--- a/fakes/azure_client.go
+++ b/fakes/azure_client.go
@@ -22,7 +22,6 @@ type AzureClient struct {
 		CallCount int
 		Receives  struct {
 			BlobName string
-			Snapshot time.Time
 		}
 		Returns struct {
 			BlobData []byte
@@ -58,10 +57,9 @@ func (a *AzureClient) ListBlobs(params storage.ListBlobsParameters) (storage.Blo
 	return a.ListBlobsCall.Returns.BlobListResponse, a.ListBlobsCall.Returns.Error
 }
 
-func (a *AzureClient) Get(blobName string, snapshot time.Time) ([]byte, error) {
+func (a *AzureClient) Get(blobName string) ([]byte, error) {
 	a.GetCall.CallCount++
 	a.GetCall.Receives.BlobName = blobName
-	a.GetCall.Receives.Snapshot = snapshot
 	return a.GetCall.Returns.BlobData, a.GetCall.Returns.Error
 }
 


### PR DESCRIPTION
for reasons entirely unclear to me, when `in` is called, it is passed
the configured payload as well as a timestamp that always ends up with
"0001-01-01 00:00:00 +0000 UTC". This causes an index out of range error
in Azure, which is returned up to the user as an HTTP 400 error. if the
file doesn't exist, the user sees http 400 with "OutOfRangeInput".

this fix removes the snapshot functionality on Get() as there is not
enough of a strong reason to snapshot a file. if
needing a snapshot of a file is needed, there are much bigger
problems that can't easily be addressed by concourse.

now the error message will properly return with 404 instead of 400.

hours Mike wasted on this bug: 7.

Signed-off-by: Mike Lloyd <mlloyd@pivotal.io>