### PR TITLE
Url inprovements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Configuration files
 config
+
+# Build assets
+assets

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,8 +88,11 @@ var _ = Describe("In", func() {
 			Expect(output.Metadata[0].Name).To(Equal("filename"))
 			Expect(output.Metadata[0].Value).To(Equal("example.json"))
 			Expect(output.Metadata[1].Name).To(Equal("url"))
-			Expect(output.Metadata[1].Value).To(Equal(fmt.Sprintf("https://%s.blob.core.windows.net/%s/example.json", config.StorageAccountName, container)))
-
+			url, err := url.Parse(output.Metadata[1].Value)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(url.Hostname()).To(Equal(fmt.Sprintf("%s.blob.core.windows.net", config.StorageAccountName)))
+			Expect(url.EscapedPath()).To(Equal(fmt.Sprintf("/%s/example.json", container)))
+			Expect(len(url.Query()["snapshot"][0])).To(Equal(28)) // azure is sensetive to trailing zero's
 			_, err = os.Stat(filepath.Join(tempDir, "example.json"))
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/api/common.go
+++ b/api/common.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"net/url"
+	"time"
+)
+
+func URLAppendTimeStamp(baseURL string, snapshot time.Time) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("snapshot", snapshot.UTC().Format("2006-01-02T15:04:05.0000000Z"))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/api/common_test.go
+++ b/api/common_test.go
@@ -1,0 +1,33 @@
+package api_test
+
+import (
+	"time"
+
+	. "github.com/pivotal-cf/azure-blobstore-resource/api"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Common", func() {
+
+	Describe("URLAppendTimeStamp", func() {
+		var (
+			baseURL string
+		)
+
+		BeforeEach(func() {
+			baseURL = "http://example.com"
+
+		})
+
+		It("keeps trailing zero's in timestamp", func() {
+			timestamp := time.Date(2017, 1, 2, 3, 4, 5, 600000*1000, time.UTC)
+			url, err := URLAppendTimeStamp(baseURL, timestamp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(url).To(Equal("http://example.com?snapshot=2017-01-02T03%3A04%3A05.6000000Z"))
+		})
+
+	})
+
+})

--- a/api/interface.go
+++ b/api/interface.go
@@ -12,4 +12,5 @@ type azureClient interface {
 	Get(blobName string, snapshot time.Time) ([]byte, error)
 	UploadFromStream(blobName string, stream io.Reader) error
 	CreateSnapshot(blobName string) (time.Time, error)
+	GetBlobURL(blobName string) (string, error)
 }

--- a/azure/client.go
+++ b/azure/client.go
@@ -111,7 +111,7 @@ func (c Client) GetBlobURL(blobName string, snapshot time.Time) (string, error) 
 		return "", err
 	}
 	q := u.Query()
-	q.Set("snapshot", snapshot.UTC().Format(time.RFC3339Nano))
+	q.Set("snapshot", snapshot.UTC().Format("2006-01-02T15:04:05.9999999Z"))
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/azure/client.go
+++ b/azure/client.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"io"
 	"io/ioutil"
-	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
@@ -97,7 +96,7 @@ func (c Client) CreateSnapshot(blobName string) (time.Time, error) {
 	return *snapshot, err
 }
 
-func (c Client) GetBlobURL(blobName string, snapshot time.Time) (string, error) {
+func (c Client) GetBlobURL(blobName string) (string, error) {
 	client, err := storage.NewBasicClient(c.storageAccountName, c.storageAccountKey)
 	if err != nil {
 		return "", err
@@ -106,12 +105,5 @@ func (c Client) GetBlobURL(blobName string, snapshot time.Time) (string, error) 
 	blobClient := client.GetBlobService()
 	cnt := blobClient.GetContainerReference(c.container)
 	blob := cnt.GetBlobReference(blobName)
-	u, err := url.Parse(blob.GetURL())
-	if err != nil {
-		return "", err
-	}
-	q := u.Query()
-	q.Set("snapshot", snapshot.UTC().Format("2006-01-02T15:04:05.9999999Z"))
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+	return blob.GetURL(), nil
 }

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/pivotal-cf/azure-blobstore-resource/api"
 	"github.com/pivotal-cf/azure-blobstore-resource/azure"
@@ -38,6 +40,11 @@ func main() {
 	url, err := azureClient.GetBlobURL(inRequest.Source.VersionedFile, inRequest.Version.Snapshot)
 	if err != nil {
 		log.Fatal("failed to get blob url: ", err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(destinationDirectory, "url"), []byte(url), os.ModePerm)
+	if err != nil {
+		log.Fatal("failed to write blob url to output directory: ", err)
 	}
 
 	versionsJSON, err := json.Marshal(api.Response{

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal("failed to copy blob: ", err)
 	}
 
-	url, err := azureClient.GetBlobURL(inRequest.Source.VersionedFile)
+	url, err := azureClient.GetBlobURL(inRequest.Source.VersionedFile, inRequest.Version.Snapshot)
 	if err != nil {
 		log.Fatal("failed to get blob url: ", err)
 	}

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -37,12 +37,17 @@ func main() {
 		log.Fatal("failed to copy blob: ", err)
 	}
 
-	url, err := azureClient.GetBlobURL(inRequest.Source.VersionedFile, inRequest.Version.Snapshot)
+	url, err := azureClient.GetBlobURL(inRequest.Source.VersionedFile)
 	if err != nil {
 		log.Fatal("failed to get blob url: ", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(destinationDirectory, "url"), []byte(url), os.ModePerm)
+	snapshotURL, err := api.URLAppendTimeStamp(url, inRequest.Version.Snapshot)
+	if err != nil {
+		log.Fatal("failed to get blob snapshot url: ", err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(destinationDirectory, "url"), []byte(snapshotURL), os.ModePerm)
 	if err != nil {
 		log.Fatal("failed to write blob url to output directory: ", err)
 	}
@@ -58,7 +63,7 @@ func main() {
 			},
 			{
 				Name:  "url",
-				Value: url,
+				Value: snapshotURL,
 			},
 		},
 	})

--- a/fakes/azure_client.go
+++ b/fakes/azure_client.go
@@ -50,6 +50,16 @@ type AzureClient struct {
 			Error    error
 		}
 	}
+	GetBlobURLCall struct {
+		CallCount int
+		Receives  struct {
+			BlobName string
+		}
+		Returns struct {
+			URL   string
+			Error error
+		}
+	}
 }
 
 func (a *AzureClient) ListBlobs(params storage.ListBlobsParameters) (storage.BlobListResponse, error) {
@@ -81,4 +91,10 @@ func (a *AzureClient) CreateSnapshot(blobName string) (time.Time, error) {
 	a.CreateSnapshotCall.CallCount++
 	a.CreateSnapshotCall.Receives.BlobName = blobName
 	return a.CreateSnapshotCall.Returns.Snapshot, a.CreateSnapshotCall.Returns.Error
+}
+
+func (a *AzureClient) GetBlobURL(blobName string) (string, error) {
+	a.GetBlobURLCall.CallCount++
+	a.GetBlobURLCall.Receives.BlobName = blobName
+	return a.GetBlobURLCall.Returns.URL, a.GetBlobURLCall.Returns.Error
 }


### PR DESCRIPTION
This PR add the [snapshot](https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob) query param to the url, in an attempt to make ensure the url actually matches the expected version of the artefact.

Additionally the `in` binary now writes the url to disk in the destination directory, this allows injecting the url to the artefact into later steps. For example this allows us to download a play-load into a created vm for the [pioneer](https://github.com/cf-platform-eng/pioneer) project.