### PR TITLE
Added support for skipping downloads (just like s3 resource)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,17 @@ the file will not be found.
 
 ### `in`: Fetch a blob from the container.
 
-Places the blob file in the destination.
+Places the following files in the destination:
+
+* `(filename)`: The file fetched from the bucket.
+
+* `url`: A file containing the URL of the object. If private is true, this URL will be signed.
+
+* `version`: The version identified in the file name.
 
 #### Parameters
+
+* `skip_download`: *Optional.* Skip downloading object.
 
 * `unpack`: *Optional.* If true, the blob will be unpacked before running the task. Supports
   tar, zip, gzip files.

--- a/api/check.go
+++ b/api/check.go
@@ -12,6 +12,7 @@ import (
 type Version struct {
 	Snapshot *time.Time `json:"snapshot,omitempty"`
 	Path     *string    `json:"path,omitempty"`
+	Version  *string    `json:"version,omitempty"`
 }
 
 type Check struct {
@@ -96,8 +97,10 @@ func (c Check) LatestVersionRegexp(expr string) (Version, error) {
 		return Version{}, fmt.Errorf("no matching blob found for regexp: %s", expr)
 	}
 
+	version := latestVersion.AsString()
 	return Version{
-		Path: &latestBlobName,
+		Path:    &latestBlobName,
+		Version: &version,
 	}, nil
 }
 

--- a/api/check_test.go
+++ b/api/check_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Check", func() {
 				Expect(azureClient.ListBlobsCall.Receives.ListBlobsParameters).To(Equal(storage.ListBlobsParameters{}))
 
 				Expect(latestVersion.Path).To(Equal(stringPtr("example-1.2.3.json")))
+				Expect(latestVersion.Version).To(Equal(stringPtr("1.2.3")))
 			})
 		})
 

--- a/api/request.go
+++ b/api/request.go
@@ -25,10 +25,12 @@ type RequestSource struct {
 type InRequestVersion struct {
 	Snapshot time.Time `json:"snapshot,omitempty"`
 	Path     string    `json:"path,omitempty"`
+	Version  string    `json:"version,omitempty"`
 }
 
 type InParams struct {
-	Unpack bool `json:"unpack"`
+	Unpack       bool `json:"unpack"`
+	SkipDownload bool `json:"skip_download"`
 }
 
 type OutParams struct {

--- a/api/response.go
+++ b/api/response.go
@@ -10,6 +10,7 @@ type Response struct {
 type ResponseVersion struct {
 	Snapshot time.Time `json:"snapshot,omitempty"`
 	Path     string    `json:"path,omitempty"`
+	Version  string    `json:"version,omitempty"`
 }
 
 type ResponseMetadata struct {

--- a/scripts/build
+++ b/scripts/build
@@ -1,5 +1,8 @@
 #!/bin/bash -exu
 
+export GOOS=linux
+export GOARCH=amd64
+
 mkdir -p assets
 go build -o assets/in ./cmd/in
 go build -o assets/out ./cmd/out


### PR DESCRIPTION
When you just want to get a url to a big blob it is useful to be able to `skip_download`.
This functionality [already exists in the s3 resource](https://github.com/concourse/s3-resource#in-fetch-an-object-from-the-bucket).