### PR TITLE
Don't return blobs which are still being copied

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -118,6 +118,18 @@ func createBlob(container, blobName string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func copyBlob(container, blobName, sourceUrl string) {
+	client, err := storage.NewBasicClient(os.Getenv("TEST_STORAGE_ACCOUNT_NAME"), os.Getenv("TEST_STORAGE_ACCOUNT_KEY"))
+	Expect(err).NotTo(HaveOccurred())
+
+	blobClient := client.GetBlobService()
+	cnt := blobClient.GetContainerReference(container)
+	blob := cnt.GetBlobReference(blobName)
+	go func() {
+		blob.Copy(sourceUrl, &storage.CopyOptions{})
+	}()
+}
+
 func uploadBlobWithSnapshot(container, blobName, filename string) *time.Time {
 	client, err := storage.NewBasicClient(os.Getenv("TEST_STORAGE_ACCOUNT_NAME"), os.Getenv("TEST_STORAGE_ACCOUNT_KEY"))
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR fixes a bug where a new version would trigger while a blob is still being copied.
This would result in jobs which depend on a new version of a blob to fail with messages like:
```
Deployment failed. Correlation ID: 185a66f1-b392-47c5-8c48-cc5c3de05dbe. {
  "error": {
    "code": "InvalidParameter",
    "message": "Cannot import source blob ... since it has not been completely copied yet. Copy status of the blob is CopyPending.",
    "target": "disks"
  }
}
```

I though about making this optional, but could not think of a use-case where you would be interested in a partially uploaded blob.