### PR TITLE
Add ca-certificates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:bionic
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    unzip
+  unzip ca-certificates
 
 ADD assets/ /opt/resource/


### PR DESCRIPTION
This PR adds the `ca-certificates` package to fix #34 