### PR TITLE
Fix out step not responding with version data

### DIFF
--- a/acceptance/out_test.go
+++ b/acceptance/out_test.go
@@ -175,13 +175,15 @@ var _ = Describe("Out", func() {
 
 			var output struct {
 				Version struct {
-					Path string `json:"path"`
+					Path    string `json:"path"`
+					Version string `json:"version"`
 				} `json:"version"`
 			}
 			err = json.Unmarshal(outputJSON, &output)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output.Version.Path).To(Equal("some-blob-sub-dir/example-1.2.txt"))
+			Expect(output.Version.Version).To(Equal("1.2"))
 		})
 	})
 })

--- a/api/check.go
+++ b/api/check.go
@@ -136,7 +136,7 @@ func (c Check) VersionsSinceRegexp(expr, currentVersion string) ([]Version, erro
 			continue // no match
 		}
 
-		index, found := findString(matcher.SubexpNames(), "version")
+		index, found := FindSubexpression(matcher.SubexpNames(), "version")
 		if found {
 			match = matches[index]
 		} else {
@@ -166,16 +166,6 @@ func (c Check) VersionsSinceRegexp(expr, currentVersion string) ([]Version, erro
 	})
 
 	return newerVersions, nil
-}
-
-func findString(items []string, searchFor string) (int, bool) {
-	for i, item := range items {
-		if item == searchFor {
-			return i, true
-		}
-	}
-
-	return -1, false
 }
 
 func stringPtr(str string) *string {

--- a/api/common.go
+++ b/api/common.go
@@ -15,3 +15,13 @@ func URLAppendTimeStamp(baseURL string, snapshot time.Time) (string, error) {
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
+
+func FindSubexpression(subexps []string, searchFor string) (int, bool) {
+	for i, item := range subexps {
+		if item == searchFor {
+			return i, true
+		}
+	}
+
+	return -1, false
+}


### PR DESCRIPTION
I took a stab at fixing #44, but would definitely appreciate feedback.

Design-wise I wasn't sure if the logic to pull out the version from the blob name should be turned into its own function and if so where it should live. The implementation in `check` loops over all the blobs in the selected blobstore and does some other interleaved work so I'm not sure if the two callsites can have the common logic extracted.

Closes #44.